### PR TITLE
Use flash.siwalik.in instead of slowly everywhere

### DIFF
--- a/appendix-1/reactor-executor-pattern.md
+++ b/appendix-1/reactor-executor-pattern.md
@@ -131,8 +131,8 @@ fn main() {
     let mut executor = Excutor::new(evt_receiver);
 
     // ===== TASK =====
-    let mut stream = TcpStream::connect("slowwly.robertomurray.co.uk:80").unwrap();
-    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: slowwly.robertomurray.co.uk\r\nConnection: close\r\n\r\n";
+    let mut stream = TcpStream::connect("flash.siwalik.in:80").unwrap();
+    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: flash.siwalik.in\r\nConnection: close\r\n\r\n";
 
     stream.write_all(request).expect("Stream write err.");
     reactor.register_stream_read_interest(&mut stream, TEST_TOKEN);
@@ -207,8 +207,8 @@ fn main() {
     let reactor = Reactor::new(evt_sender);
     let mut executor = Excutor::new(evt_receiver);
 
-    let mut stream = TcpStream::connect("slowwly.robertomurray.co.uk:80").unwrap();
-    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: slowwly.robertomurray.co.uk\r\nConnection: close\r\n\r\n";
+    let mut stream = TcpStream::connect("flash.siwalik.in:80").unwrap();
+    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: flash.siwalik.in\r\nConnection: close\r\n\r\n";
 
     stream.write_all(request).expect("Stream write err.");
     reactor.register_stream_read_interest(&mut stream, TEST_TOKEN);

--- a/part-1-an-express-explanation/iocp-the-express-version.md
+++ b/part-1-an-express-explanation/iocp-the-express-version.md
@@ -185,13 +185,13 @@ fn main() {
     // We create 5 requests to an endpoint we control the delay on
     for i in 1..6 {
         // This site has an API to simulate slow responses from a server
-        let addr = "slowwly.robertomurray.co.uk:80";
+        let addr = "flash.siwalik.in:80";
         let mut stream = TcpStream::connect(addr).unwrap();
 
         let delay = (5 - i) * 1000;
         let request = format!(
             "GET /delay/{}/url/http://www.google.com HTTP/1.1\r\n\
-             Host: slowwly.robertomurray.co.uk\r\n\
+             Host: flash.siwalik.in\r\n\
              Connection: close\r\n\
              \r\n",
             delay

--- a/part-1-an-express-explanation/kqueue-the-express-version.md
+++ b/part-1-an-express-explanation/kqueue-the-express-version.md
@@ -100,7 +100,7 @@ fn main() {
     // We crate 5 requests to an endpoint we control the delay on
     for i in 1..6 {
         // This site has an API to simulate slow responses from a server
-        let addr = "slowwly.robertomurray.co.uk:80";
+        let addr = "flash.siwalik.in:80";
         let mut stream = TcpStream::connect(addr).unwrap();
 
         // The delay is passed in to the GET request as milliseconds.
@@ -109,7 +109,7 @@ fn main() {
         let delay = (5 - i) * 1000;
         let request = format!(
             "GET /delay/{}/url/http://www.google.com HTTP/1.1\r\n\
-             Host: slowwly.robertomurray.co.uk\r\n\
+             Host: flash.siwalik.in\r\n\
              Connection: close\r\n\
              \r\n",
             delay

--- a/the-recipie-for-an-eventqueue/untitled.md
+++ b/the-recipie-for-an-eventqueue/untitled.md
@@ -199,8 +199,8 @@ fn proposed_api() {
     let mut reactor = Reactor::new(evt_sender);
     let mut executor = Excutor::new(evt_receiver);
 
-    let mut stream = TcpStream::connect("slowwly.robertomurray.co.uk:80").unwrap();
-    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: slowwly.robertomurray.co.uk\r\nConnection: close\r\n\r\n";
+    let mut stream = TcpStream::connect("flash.siwalik.in:80").unwrap();
+    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: flash.siwalik.in\r\nConnection: close\r\n\r\n";
 
     stream.write_all(request).expect("Stream write err.");
 
@@ -221,7 +221,7 @@ fn proposed_api() {
 **The interesting lines here are:**
 
 ```rust
-let mut stream = TcpStream::connect("slowwly.robertomurray.co.uk:80").unwrap();
+let mut stream = TcpStream::connect("flash.siwalik.in:80").unwrap();
 let registrator = reactor.registrator();
 registrator.register(&mut stream, TEST_TOKEN, Interests::READABLE).expect("...");
 registrator.close_loop().expect("close loop err.");
@@ -262,8 +262,8 @@ fn proposed_api() {
     let mut reactor = Reactor::new(evt_sender);
     let mut executor = Excutor::new(evt_receiver);
 
-    let mut stream = TcpStream::connect("slowwly.robertomurray.co.uk:80").unwrap();
-    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: slowwly.robertomurray.co.uk\r\nConnection: close\r\n\r\n";
+    let mut stream = TcpStream::connect("flash.siwalik.in:80").unwrap();
+    let request = b"GET /delay/1000/url/http://www.google.com HTTP/1.1\r\nHost: flash.siwalik.in\r\nConnection: close\r\n\r\n";
 
     stream.write_all(request).expect("Stream write err.");
 


### PR DESCRIPTION
First of all, thanks for a nice writeup!

Some instances of slowly were replaced with flash.siwalik.in in [Use flash.siwalik.in instead of slowwly by akoshelev · Pull Request #9 · cfsamson/book-exploring-epoll-kqueue-iocp](https://github.com/cfsamson/book-exploring-epoll-kqueue-iocp/pull/9).
This commit replaces all other instances of slowly with flash.siwalik.in.