### PR TITLE
Add format string literal to panic

### DIFF
--- a/part-1-an-express-explanation/iocp-the-express-version.md
+++ b/part-1-an-express-explanation/iocp-the-express-version.md
@@ -160,7 +160,7 @@ fn main() {
         unsafe { ffi::CreateIoCompletionPort(ffi::INVALID_HANDLE_VALUE, 0, ptr::null_mut(), 0) };
     // We handle any error here panicking.
     if (queue as *mut usize).is_null() {
-        panic!(std::io::Error::last_os_error());
+        panic!("{}", std::io::Error::last_os_error());
     }
 
     // As you'll see below, we need a place to store the streams so they're
@@ -209,7 +209,7 @@ fn main() {
         };
 
         if (res as *mut usize).is_null() {
-            panic!(std::io::Error::last_os_error());
+            panic!("{}", std::io::Error::last_os_error());
         }
 
         // crate a zeroed WSAOVERLAPPED struct
@@ -258,7 +258,7 @@ fn main() {
                 // Everything is OK, and we can wait this with GetQueuedCompletionStatus
                 ()
             } else {
-                panic!(std::io::Error::last_os_error());
+                panic!("{}", std::io::Error::last_os_error());
             }
         } else {
             // The socket is already ready so we don't need to queue it
@@ -297,7 +297,7 @@ fn main() {
         };
 
         if res == 0 {
-            panic!(io::Error::last_os_error());
+            panic!("{}", std::io::Error::last_os_error());
         };
 
         // This one unsafe we could avoid though but this technique is used
@@ -317,7 +317,7 @@ fn main() {
     // implementation which takes care of this for us.
     let res = unsafe { ffi::CloseHandle(queue) };
     if res == 0 {
-        panic!(io::Error::last_os_error());
+        panic!("{}", std::io::Error::last_os_error());
     };
     println!("FINISHED");
 }

--- a/part-1-an-express-explanation/kqueue-the-express-version.md
+++ b/part-1-an-express-explanation/kqueue-the-express-version.md
@@ -90,7 +90,7 @@ fn main() {
     let queue = unsafe { ffi::kqueue() };
     // We handle errors in this example by just panicking.
     if queue < 0 {
-        panic!(io::Error::last_os_error());
+        panic!("{}", std::io::Error::last_os_error());
     }
 
     // As you'll see below, we need a place to store the streams so they're
@@ -161,7 +161,7 @@ fn main() {
         )};
 
         if res < 0 {
-            panic!(io::Error::last_os_error());
+            panic!("{}", std::io::Error::last_os_error());
         }
 
         // Letting `stream` go out of scope in Rust automatically runs
@@ -196,7 +196,7 @@ fn main() {
         // This result will return the number of events which occurred
         // (if any) or a negative number if it's an error.
         if res < 0 {
-            panic!(io::Error::last_os_error());
+            panic!("{}", std::io::Error::last_os_error());
         };
 
         // This one unsafe we could avoid though but this technique is used
@@ -215,7 +215,7 @@ fn main() {
     // implementation which takes care of this for us.
     let res = unsafe { ffi::close(queue) };
     if res < 0 {
-        panic!(io::Error::last_os_error());
+        panic!("{}", std::io::Error::last_os_error());
     }
     println!("FINISHED");
 }

--- a/part-1-an-express-explanation/the-basics.md
+++ b/part-1-an-express-explanation/the-basics.md
@@ -105,7 +105,7 @@ fn main() {
     // C APIs
     // We handle them by just panicking here in our example.
     if queue < 0 {
-        panic!(io::Error::last_os_error());
+        panic!("{}", std::io::Error::last_os_error());
     }
 
     // As you'll see below, we need a place to store the streams so they're
@@ -162,7 +162,7 @@ fn main() {
             ffi::epoll_ctl(queue, op, stream.as_raw_fd(), &mut event)
         };
         if res < 0 {
-            panic!(io::Error::last_os_error());
+            panic!("{}", std::io::Error::last_os_error());
         }
 
         // Letting `stream` go out of scope in Rust automatically runs
@@ -187,7 +187,7 @@ fn main() {
         // This result will return the number of events which occurred
         // (if any) or a negative number in case of an error.
         if res < 0 {
-            panic!(io::Error::last_os_error());
+            panic!("{}", std::io::Error::last_os_error());
         };
 
         // This one unsafe we could avoid though but this technique is used
@@ -206,7 +206,7 @@ fn main() {
     // implementation which takes care of this for us.
     let res = unsafe { ffi::close(queue) };
     if res < 0 {
-        panic!(io::Error::last_os_error());
+        panic!("{}", std::io::Error::last_os_error());
     }
     println!("FINISHED");
 }


### PR DESCRIPTION
Without this change, `cargo build` gives the following error.

```
error: format argument must be a string literal
   --> src\main.rs:175:16
    |
175 |         panic!(io::Error::last_os_error());
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
help: you might be missing a string literal to format with
    |
175 |         panic!("{}", io::Error::last_os_error());
    |                +++++
```

The above error is given by rustc 1.62.1 (e092d0b6b 2022-07-16)