### PR TITLE
Fix entries count after GetQueuedCompletionStatusEx in IOCP example

### DIFF
--- a/part-1-an-express-explanation/iocp-the-express-version.md
+++ b/part-1-an-express-explanation/iocp-the-express-version.md
@@ -303,7 +303,7 @@ fn main() {
         // This one unsafe we could avoid though but this technique is used
         // in libraries like `mio` and is safe as long as the OS does
         // what it's supposed to.
-        unsafe { events.set_len(res as usize) };
+        unsafe { events.set_len(entries_removed as usize) };
 
         for event in events {
             let operation = unsafe { &*(event.lp_overlapped as *const Operation) };


### PR DESCRIPTION
Without this fix, less than five "RECEIVED: {}" are printed and
"FINISHED" is never printed.

See https://github.com/tokio-rs/mio/blob/ef191617368eca5f49e3250f96f10c657d2ed768/src/sys/windows/iocp.rs#L114